### PR TITLE
Fix views

### DIFF
--- a/fgkeyboard.xml
+++ b/fgkeyboard.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Keyboard bindings for fgcamera -->
 <PropertyList>
+<!--
     <key n="32">
         <name>Space</name>
         <desc>toggle mouse mode</desc>
@@ -10,6 +11,7 @@
             <script>fgcamera.toggleYoke()</script>
         </binding>
     </key>
+-->
 
     <key n="360">
 				<mod-shift>

--- a/fgmouse.xml
+++ b/fgmouse.xml
@@ -248,7 +248,7 @@ current mode for each mouse is held in the
 					</condition>
 					<command>property-adjust</command>
 					<property>/sim/fgcamera/mouse/heading-offset</property>
-					<factor>100.0</factor>
+					<factor>-100.0</factor>
 				</binding>
 				<binding>
 					<condition>
@@ -295,7 +295,7 @@ current mode for each mouse is held in the
 					</condition>
 					<command>property-adjust</command>
 					<property>/sim/fgcamera/mouse/pitch-offset</property>
-					<factor>100.0</factor>
+					<factor>-100.0</factor>
 				</binding>
 				<binding>
 					<condition>
@@ -364,7 +364,7 @@ current mode for each mouse is held in the
 					</condition>
 					<command>property-adjust</command>
 					<property>/sim/fgcamera/mouse/heading-offset</property>
-					<factor>100.0</factor>
+					<factor>-100.0</factor>
 				</binding>
 				<binding>
 					<condition>
@@ -391,7 +391,7 @@ current mode for each mouse is held in the
 					</condition>
 					<command>property-adjust</command>
 					<property>/sim/fgcamera/mouse/pitch-offset</property>
-					<factor>100.0</factor>
+					<factor>-100.0</factor>
 				</binding>
 				<binding>
 					<condition>

--- a/fgmouse.xml
+++ b/fgmouse.xml
@@ -175,6 +175,7 @@ current mode for each mouse is held in the
 				<binding>
 					<condition>
 						<property>/sim/fgcamera/fgcamera-enabled</property>
+                        <not><property>/sim/fgcamera/mouse/spring-loaded</property></not>
 					</condition>
 					<command>fgcamera-reset-view</command>
 				</binding>
@@ -192,7 +193,8 @@ current mode for each mouse is held in the
 				</binding>
 				<binding>
 					<condition>
-						<property>/devices/status/mice/mouse[0]/button[1]</property>
+                        <not><property>/devices/status/mice/mouse[0]/button[2]</property></not>
+                        <property>/devices/status/mice/mouse[0]/button[1]</property>
 					</condition>
 					<command>nasal</command>
 					<script>
@@ -245,6 +247,7 @@ current mode for each mouse is held in the
 				<binding>
 					<condition>
 						<property>/sim/fgcamera/fgcamera-enabled</property>
+                        <not><property>/devices/status/mice/mouse[0]/button[1]</property></not>
 					</condition>
 					<command>property-adjust</command>
 					<property>/sim/fgcamera/mouse/heading-offset</property>
@@ -283,6 +286,17 @@ current mode for each mouse is held in the
 					<factor type="double">1</factor>
 					<wrap type="bool">false</wrap>
 				</binding>
+                <binding>
+                    <!-- move view up/down with fgcamera with MMB+RMB -->
+					<condition>
+						<property>/sim/fgcamera/fgcamera-enabled</property>
+                        <property>/devices/status/mice/mouse[0]/button[1]</property>
+                        <property>/devices/status/mice/mouse[0]/button[2]</property>
+					</condition>
+                    <command>property-adjust</command>
+                    <property>/sim/fgcamera/mouse/x-offset</property>
+					<factor>1.0</factor>
+				</binding>
 			</x-axis>
 
 			<!-- Mouse up/down motion -->
@@ -292,10 +306,22 @@ current mode for each mouse is held in the
 				<binding>
 					<condition>
 						<property>/sim/fgcamera/fgcamera-enabled</property>
+                        <not><property>/devices/status/mice/mouse[0]/button[1]</property></not>
 					</condition>
 					<command>property-adjust</command>
 					<property>/sim/fgcamera/mouse/pitch-offset</property>
 					<factor>-100.0</factor>
+				</binding>
+                <binding>
+                    <!-- move view up/down with fgcamera with MMB+RMB -->
+					<condition>
+						<property>/sim/fgcamera/fgcamera-enabled</property>
+                        <property>/devices/status/mice/mouse[0]/button[1]</property>
+                        <property>/devices/status/mice/mouse[0]/button[2]</property>
+					</condition>
+                    <command>property-adjust</command>
+                    <property>/sim/fgcamera/mouse/y-offset</property>
+					<factor>-1.0</factor>
 				</binding>
 				<binding>
 					<condition>
@@ -346,6 +372,17 @@ current mode for each mouse is held in the
 					<factor type="double">1</factor>
 					<wrap type="bool">false</wrap>
 				</binding>
+                <binding>
+                    <!-- move view forward/backward with fgcamera with MMB+RMB -->
+					<condition>
+						<property>/sim/fgcamera/fgcamera-enabled</property>
+                        <property>/devices/status/mice/mouse[0]/button[1]</property>
+                        <property>/devices/status/mice/mouse[0]/button[2]</property>
+					</condition>
+                    <command>property-adjust</command>
+                    <property>/sim/fgcamera/mouse/z-offset</property>
+					<factor>1.0</factor>
+				</binding>
 			</y-axis-ctrl>
 		</mode>
 
@@ -388,6 +425,7 @@ current mode for each mouse is held in the
 				<binding>
 					<condition>
 						<property>/sim/fgcamera/fgcamera-enabled</property>
+                        <not><property>/devices/status/mice/mouse[0]/button[1]</property></not>
 					</condition>
 					<command>property-adjust</command>
 					<property>/sim/fgcamera/mouse/pitch-offset</property>

--- a/readme.aircraft-integration.md
+++ b/readme.aircraft-integration.md
@@ -1,0 +1,14 @@
+Aircraft integration 
+=====================
+This file documents some integration API for your aircraft nasal code.
+
+### Walker compatibility callbacks
+
+|Callback / Variable|Description|
+|-----------------------|---------------|
+|`fgcamera.walkerGetoutTime`|wait time in seconds after the GetOut callback executed|
+|`fgcamera.walkerGetinTime`|wait time in seconds after the GetIn callback executed|
+|`fgcamera.walkerGetout_callback()`|callback  when getting out|
+|`fgcamera.walkerGetin_callback()`|callback when getting in|
+
+The `fgcamera.nas` code contains an example at the end for the C182S which opens the door if not open yet.


### PR DESCRIPTION
- [x] Fixes #5
- [x] Fixes #3
- [x] Fixes #10

For later:
- [ ] Fixes # 4 
- [ ] make camera controls comply to default cam controls
- [ ] make advanced keybind controls off by default but toggleable in fgcamera cfg
- [ ] make `ctrl+v` switch on default fgcamera instead of traditional one
- [ ] make `v` / `shift+v`cycle trough fgcamera views first before traditional ones
- [ ] find free keybinds for fgcams quick access (`ctrl+<num>`?)

----
This PR introduces some callbacks for the walk view, that are meant to be overriden from aircraft nasal code (see `readme.aircraft-integration.md`).